### PR TITLE
Add simple Spring Boot API with product endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+*.iml
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,50 +1,19 @@
-# React + TypeScript + Vite
+# API em Java com Spring Boot
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Este projeto demonstra um exemplo simples de API de produtos usando Spring Boot.
+Inclui um controller `ProdutoController` com operações básicas de CRUD.
 
-Currently, two official plugins are available:
+Para executar o projeto, é necessário ter Java instalado. O Maven Wrapper está
+incluído para facilitar a construção e execução.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+./mvnw spring-boot:run
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+Os endpoints disponíveis são:
+- `GET /produto`
+- `POST /produto`
+- `DELETE /produto/{id}`
+- `PUT /produto/{id}`
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
-
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
-```
+O projeto também possui o actuator habilitado em `/actuator/health`.

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+if command -v mvn >/dev/null 2>&1; then
+  mvn "$@"
+else
+  echo "Maven is not installed."
+  exit 1
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.projeto</groupId>
+    <artifactId>api</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Meu primeiro projeto de API em Java</name>
+    <description>Meu primeiro projeto de API em Java</description>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/projeto/api/ApiApplication.java
+++ b/src/main/java/com/projeto/api/ApiApplication.java
@@ -1,0 +1,11 @@
+package com.projeto.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ApiApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ApiApplication.class, args);
+    }
+}

--- a/src/main/java/com/projeto/api/produto/ProdutoController.java
+++ b/src/main/java/com/projeto/api/produto/ProdutoController.java
@@ -1,0 +1,38 @@
+package com.projeto.api.produto;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/produto")
+public class ProdutoController {
+
+    @GetMapping
+    public String listaProdutos() {
+        return "Lista de produtos";
+    }
+
+    @PostMapping
+    public String criaProduto(@RequestBody String nome, String preco, String categoria) {
+        return "Produto criado com sucesso";
+    }
+
+    @DeleteMapping("/{id}")
+    public String deletaProduto(@PathVariable("id") String id) {
+        return "Produto deletado com sucesso";
+    }
+
+    @PutMapping("/{id}")
+    public String atualizaProduto(@PathVariable("id") String id,
+                                  String nome,
+                                  String preco,
+                                  String categoria) {
+        return "Produto atualizado com sucesso";
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Spring Boot API project
- add actuator and web dependencies
- create ProdutoController and ApiApplication
- document usage in README

## Testing
- `./mvnw -q test` *(fails: Maven is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685db49aaa5c8328af45573618874eae